### PR TITLE
add logic to handle restricted tlds and also use jsonp

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
     "react-scripts": "1.0.14",
     "react-test-renderer": "^16.0.0",
     "sinon": "^4.0.0",
-    "whatwg-fetch": "^2.0.3"
+    "fetch-jsonp": "^1.1.3"
   }
 }

--- a/public/store.css
+++ b/public/store.css
@@ -206,6 +206,10 @@ hr {
   border: 3px solid #e8e8e8;
 }
 
+.rstore-domain-search .rstore-exact-domain-list h4.not-available {
+    margin: 15px 0 15px 0;
+}
+
 .rstore-domain-search .domain-name {
   display: inline-block;
   vertical-align: middle;
@@ -214,7 +218,7 @@ hr {
   padding: 10px 0;
 }
 
-.rstore-domain-search .continue-block {
+.rstore-domain-search .rstore-domain-continue-button {
   display: block;
   float: right;
 }
@@ -237,4 +241,8 @@ hr {
 
 .rstore-domain-search .rstore-domain-buy-button {
   margin-left: 10px;
+}
+
+.rstore-domain-search .rstore-disclaimer {
+  clear: both;
 }

--- a/src/Domain.js
+++ b/src/Domain.js
@@ -22,7 +22,8 @@ export default class Domain extends Component {
     const {
       domain,
       listPrice,
-      salePrice
+      salePrice,
+      extendedValidation
     } = this.props.domainResult;
 
     const {
@@ -30,6 +31,8 @@ export default class Domain extends Component {
     } = this.state;
 
     let content;
+
+    const buttonText = extendedValidation ? this.props.text.verify : this.props.text.select;
 
     if (selected) {
       content = (
@@ -43,8 +46,8 @@ export default class Domain extends Component {
       content = (
         <div className="rstore-message">
           {listPrice !== salePrice && <span className="listPrice"><small><s>{listPrice}</s></small></span>}
-          <span className="salePrice"><strong>{salePrice}</strong></span>
-           <a className="rstore-domain-buy-button submit button select" onClick={this.handleSelectClick}>{this.props.text.select}</a>
+          <span className="salePrice"><strong>{salePrice}{extendedValidation && '*'}</strong></span>
+           <a className="rstore-domain-buy-button submit button select" onClick={this.handleSelectClick}>{buttonText}</a>
         </div>
       );
     }

--- a/src/DomainSearch.js
+++ b/src/DomainSearch.js
@@ -71,6 +71,7 @@ export default class DomainSearch extends Component {
       baseUrl,
       plid
     } = this.props;
+
     const cartUrl = `https://storefront.api.${baseUrl}/api/v1/cart/${plid}/`;
     const items =[];
 
@@ -89,20 +90,26 @@ export default class DomainSearch extends Component {
 
   handleContinueClick(e) {
     e.preventDefault();
+
     const {
       baseUrl,
       plid
     } = this.props;
 
+    const {
+      selectedDomains,
+      exactDomain
+    } = this.state;
+
     this.setState({ addingToCart: true });
 
     let domains;
 
-    if (this.state.selectedDomains.length === 0 && this.state.exactDomain.available) {
-      domains = [this.state.exactDomain];
+    if (selectedDomains.length === 0 && exactDomain.available) {
+      domains = [exactDomain];
     }
     else {
-      domains = this.state.selectedDomains;
+      domains = selectedDomains;
     }
 
     this.addDomainsToCart(
@@ -130,18 +137,29 @@ export default class DomainSearch extends Component {
   }
 
   handleSelectClick(domainObj) {
-    const { selectedDomains } = this.state,
-      { domain, extendedValidation } = domainObj.props.domainResult,
-      { baseUrl, plid } = this.props;
+    const { selectedDomains } = this.state;
+
+    const {
+      domain,
+      extendedValidation
+    } = domainObj.props.domainResult;
+
+    const {
+      baseUrl,
+      plid
+    } = this.props;
 
     if (extendedValidation) {
-      this.setState({addingToCart: true})
+      this.setState({ addingToCart: true });
+
       const url = `https://www.${baseUrl}/domains/search.aspx?checkAvail=1&plid=${plid}`;
+
       return util.postDomain(url, domain);
     }
 
     const index = selectedDomains.indexOf(domainObj.props.domainResult);
     let newSelectDomains = [];
+
     if (index >= 0 ){
       newSelectDomains = [
         ...selectedDomains.slice(0, index),

--- a/src/SearchResults.js
+++ b/src/SearchResults.js
@@ -4,12 +4,10 @@ import Domain from './Domain';
 
 const SearchResults = ({ domains, text,  cartClick}) => {
   return (
-    <div>
-      <div className="rstore-domain-list">
-        {domains.map((domain, index) => {
-          return domain.available && (<Domain key={index} domainResult={domain} text={text} cartClick={cartClick}/>);
-        })}
-      </div>
+    <div className="rstore-domain-list">
+      {domains.map((domain, index) => {
+        return domain.available && (<Domain key={index} domainResult={domain} text={text} cartClick={cartClick}/>);
+      })}
     </div>
   );
 };

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,9 @@ Array.prototype.forEach.call(elements, element => {
     notAvailable: element.dataset.text_not_available || "Sorry, that domain is taken",
     cart: element.dataset.text_cart || "Continue to Cart",
     select: element.dataset.text_select || "Select",
-    selected: element.dataset.text_selected || "Selected"
+    selected: element.dataset.text_selected || "Selected",
+    verify: element.dataset.text_verify || "Verify",
+    disclaimer: element.dataset.text_disclaimer || "Taxes and ICANN fee not included in price displayed.\n*Additional charges and registration restrictions may apply."
   },
   baseUrl = element.dataset.base_url || "secureserver.net",
   pageSize = element.dataset.page_size || "5";

--- a/src/tests/Domain.test.js
+++ b/src/tests/Domain.test.js
@@ -28,6 +28,15 @@ describe('Domain', () => {
     shallow(<Domain {...props} />);
   });
 
+  it('should render Domain component for restricted domains', () => {
+    const newProps = {
+      ...props,
+      domainResult: {extendedValidation: true}
+    };
+
+    shallow(<Domain {...newProps} />);
+  });
+
   it('should successfully add when domain is selected', () => {
     const wrapper = mount(<Domain {...props} />);
 

--- a/src/tests/util.test.js
+++ b/src/tests/util.test.js
@@ -1,5 +1,6 @@
 import sinon from 'sinon';
 import util from '../util';
+import fetchJsonp from 'fetch-jsonp';
 
 let sandbox;
 
@@ -29,6 +30,12 @@ describe('util', () => {
       }));
 
       util.fetch('test.com', {});
+    });
+  });
+
+  describe('Given postDomain', () => {
+    it('should form post the domain to the url', () => {
+      util.postDomain('#', 'test.com');
     });
   });
 });

--- a/src/util.js
+++ b/src/util.js
@@ -14,12 +14,12 @@ const fetchjsonp = url => fetchJsonp(url)
   });
 
 const postDomain = (url, domain) => {
-  var form = document.createElement('form');
+  const form = document.createElement('form');
   form.style.visibility = 'hidden';
   form.method = 'POST';
   form.action = url;
 
-  var input = document.createElement('input');
+  const input = document.createElement('input');
   input.name = 'domainToCheck';
   input.value = domain;
   form.appendChild(input);

--- a/src/util.js
+++ b/src/util.js
@@ -1,3 +1,5 @@
+import fetchJsonp from 'fetch-jsonp';
+
 const fetch = (url, options) => global.fetch(url, options)
   .then(response => {
     return response.text().then( text => {
@@ -5,4 +7,25 @@ const fetch = (url, options) => global.fetch(url, options)
     });
   });
 
-export default { fetch };
+// istanbul ignore next
+const fetchjsonp = url => fetchJsonp(url)
+  .then(response => {
+    return response.json();
+  });
+
+const postDomain = (url, domain) => {
+  var form = document.createElement('form');
+  form.style.visibility = 'hidden';
+  form.method = 'POST';
+  form.action = url;
+
+  var input = document.createElement('input');
+  input.name = 'domainToCheck';
+  input.value = domain;
+  form.appendChild(input);
+
+  document.body.appendChild(form);
+  form.submit();
+}
+
+export default { fetch, fetchJsonp: fetchjsonp, postDomain };


### PR DESCRIPTION
The domain search api returns an `extendedValidation` property if the domain requires additional information.  the search will now `POST` to the dpp so that the shopper can provide the additional information requried

Also now performs a jsonp request to add the domain to cart to better support more browsers.

cc: @Lobstrosity