### PR TITLE
Post to Cart URL when Continuing to Cart

### DIFF
--- a/public/store.css
+++ b/public/store.css
@@ -107,6 +107,15 @@ hr {
   display: inline-block;
 }
 
+.form-container {
+  display: flex;
+  align-items: center;
+}
+
+.search-form {
+  flex-grow: 1;
+}
+
 .search-form .search-field {
   width: 80%;
   background: #fff;
@@ -161,7 +170,7 @@ hr {
 }
 
 @media (min-width: 991px) {
-  .rstore-domain-search .input-group2 {
+  .rstore-domain-search {
     display: table;
     border-collapse: separate;
     width: 100%;
@@ -175,19 +184,19 @@ hr {
     width: 100%;
   }
 
-  .rstore-domain-search .input-continue-btn {
+  .rstore-domain-search {
     display: table-cell;
     width: 1%;
     white-space: nowrap;
   }
 
-  .rstore-domain-search .input-continue-btn button {
+  .rstore-domain-search button {
     margin-left: 10px;
   }
 }
 
 @media (max-width: 1200px) {
-  .rstore-domain-search .input-continue-btn button {
+  .rstore-domain-search button {
     position: relative;
     width: 100%;
     margin-top: .3em;

--- a/public/store.css
+++ b/public/store.css
@@ -191,7 +191,8 @@ hr {
   }
 
   .rstore-domain-search button {
-    margin-left: 10px;
+    margin: 10px;
+    float: right;
   }
 }
 

--- a/src/Domain.js
+++ b/src/Domain.js
@@ -30,7 +30,7 @@ export default class Domain extends Component {
       content = (
         <div className="rstore-message">
           <span className="dashicons dashicons-yes rstore-success"></span>
-          <a className="rstore-domain-buy-button submit button selected btn btn-default" onClick={ ()=>cartClick(this) }>{ text.selected }</a>
+          <button className="rstore-domain-buy-button selected btn btn-default" onClick={ ()=>cartClick(this) }>{ text.selected }</button>
         </div>
       );
     }
@@ -39,7 +39,7 @@ export default class Domain extends Component {
         <div className="rstore-message">
           { listPrice !== salePrice && <span className="listPrice"><small><s>{ listPrice }</s></small></span> }
           <span className="salePrice"><strong>{ salePrice}{extendedValidation && '*' }</strong></span>
-           <a className="rstore-domain-buy-button submit button select btn btn-secondary" onClick={ ()=>cartClick(this) }>{ text.select }</a>
+           <button className="rstore-domain-buy-button select btn btn-secondary" onClick={ ()=>cartClick(this) }>{ text.select }</button>
         </div>
       );
     }

--- a/src/DomainSearch.js
+++ b/src/DomainSearch.js
@@ -77,7 +77,7 @@ export default class DomainSearch extends Component {
     if (index >= 0 ){
       newSelectDomains = [
         ...selectedDomains.slice(0, index),
-        ...selectedDomains.slice(index+1)
+        ...selectedDomains.slice(index + 1)
       ];
 
       domainObj.setState({

--- a/src/DomainSearch.js
+++ b/src/DomainSearch.js
@@ -161,6 +161,44 @@ export default class DomainSearch extends Component {
     this.setState({ selectedDomains: newSelectDomains });
   }
 
+  generateCartItems() {
+    const {
+      baseUrl,
+      plid
+    } = this.props;
+
+    const {
+      selectedDomains,
+      results
+    } = this.state;
+
+    const items = [];
+
+    if (results) {
+      const domainCount = selectedDomains.length;
+      const hasExactMatch = results && results.exactMatchDomain && results.exactMatchDomain.available;
+      const cartUrl = `https://www.${baseUrl}/api/v1/cart/${plid}/`;
+
+      let domains;
+
+      if (selectedDomains.length === 0 && results.exactMatchDomain.available) {
+        domains = [results.exactMatchDomain];
+      }
+      else {
+        domains = selectedDomains;
+      }
+
+      domains.forEach(item => {
+        items.push({
+          id: 'domain',
+          domain: item.domain
+        });
+      });
+    }
+
+    return JSON.stringify({ items });
+  }
+
   render() {
     const {
       searching,
@@ -172,6 +210,7 @@ export default class DomainSearch extends Component {
 
     const domainCount = selectedDomains.length;
     const hasExactMatch = results && results.exactMatchDomain && results.exactMatchDomain.available;
+    const items = this.generateCartItems();
 
     // Prevent navigation when domains are selected and user attempts to navigate
     // outside of the domain purchase path
@@ -181,28 +220,34 @@ export default class DomainSearch extends Component {
     };
 
     return (
-      <form className="search-form" onSubmit={ this.handleDomainSearch }>
-        <div className="input-group">
-          <div className="input-group2">
-            <label>
-              <input type="search" value={ this.state.domain } onChange={ this.handleChange } className="search-field" placeholder={ this.props.text.placeholder } />
-            </label>
-            <input type="submit" className="rstore-domain-search-button search-submit btn btn-primary" disabled={ searching } value={ this.props.text.search }/>
+      <div>
+        <form className="search-form" onSubmit={ this.handleDomainSearch }>
+          <div className="input-group">
+            <div className="input-group2">
+              <label>
+                <input type="search" value={ this.state.domain } onChange={ this.handleChange } className="search-field" placeholder={ this.props.text.placeholder } />
+              </label>
+              <input type="submit" className="rstore-domain-search-button search-submit btn btn-primary" disabled={ searching } value={ this.props.text.search }/>
+            </div>
           </div>
-          { results && <span className="input-continue-btn">
+            { error && <div className="rstore-error">Error: { error }</div> }
+            { (addingToCart || searching) && <div className="rstore-loading"></div> }
+            { results && <SearchResults results={ results } cartClick={ domain => this.handleSelectClick(domain) } text={ this.props.text }/> }
+        </form>
+
+        { results &&
+          <form className="input-continue-btn" method="POST">
+            <input type="hidden" name="items" value={ items } />
             <button type="button" className="rstore-domain-continue-button btn btn-secondary"
               onClick={ this.handleContinueClick }
               disabled={ domainCount === 0 && !hasExactMatch }
-              >
+            >
               { this.props.text.cart }
               { (domainCount > 0) && `(${domainCount} ${this.props.text.selected})` }
             </button>
-          </span> }
-        </div>
-          { error && <div className="rstore-error">Error: { error }</div> }
-          { (addingToCart || searching) && <div className="rstore-loading"></div> }
-          { results && <SearchResults results={ results } cartClick={ domain => this.handleSelectClick(domain) } text={ this.props.text }/> }
-      </form>
+          </form>
+        }
+      </div>
     );
   }
 }

--- a/src/DomainSearch.js
+++ b/src/DomainSearch.js
@@ -7,7 +7,7 @@ import util from './util';
 const initialState = {
   results: null,
   searching: false,
-  addingToCart: false,
+  submitting: false,
   error: '',
   selectedDomains: [],
   hasError: false,
@@ -68,69 +68,6 @@ export default class DomainSearch extends Component {
     }
   }
 
-  addDomainsToCart(domains) {
-    const {
-      baseUrl,
-      plid
-    } = this.props;
-
-    const cartUrl = `https://www.${baseUrl}/api/v1/cart/${plid}/`;
-    const items =[];
-
-    domains.forEach(item => {
-      items.push({
-        id: 'domain',
-        domain: item.domain
-      });
-    });
-
-    var cart = JSON.stringify({ items });
-
-    return util.fetchJsonp(cartUrl, { cart });
-  }
-
-  handleContinueClick(e) {
-    e.preventDefault();
-
-    const {
-      selectedDomains,
-      results
-    } = this.state;
-
-    this.setState({ addingToCart: true });
-
-    let domains;
-
-    if (selectedDomains.length === 0 && results.exactMatchDomain.available) {
-      domains = [results.exactMatchDomain];
-    }
-    else {
-      domains = selectedDomains;
-    }
-
-    this.addDomainsToCart(
-      domains
-    ).then(response => {
-      if (response.NextStepUrl) {
-       return window.location.href = response.NextStepUrl;
-      }
-
-      if (response.error){
-        return this.setState({
-          addingToCart: false,
-          error: response.error.message
-        });
-      }
-
-
-    }).catch(error => {
-      this.setState({
-        addingToCart: false,
-        error: error.message
-      });
-    });
-  }
-
   handleSelectClick(domainObj) {
     const { selectedDomains } = this.state;
 
@@ -161,12 +98,11 @@ export default class DomainSearch extends Component {
     this.setState({ selectedDomains: newSelectDomains });
   }
 
-  generateCartItems() {
-    const {
-      baseUrl,
-      plid
-    } = this.props;
+  handleContinueClick() {
+    this.setState({ submitting: true })
+  }
 
+  generateCartItems() {
     const {
       selectedDomains,
       results
@@ -177,7 +113,6 @@ export default class DomainSearch extends Component {
     if (results) {
       const domainCount = selectedDomains.length;
       const hasExactMatch = results && results.exactMatchDomain && results.exactMatchDomain.available;
-      const cartUrl = `https://www.${baseUrl}/api/v1/cart/${plid}/`;
 
       let domains;
 
@@ -196,13 +131,19 @@ export default class DomainSearch extends Component {
       });
     }
 
-    return JSON.stringify({ items });
+    return JSON.stringify(items);
   }
 
   render() {
     const {
+      baseUrl,
+      plid,
+      text
+    } = this.props;
+
+    const {
       searching,
-      addingToCart,
+      submitting,
       results,
       selectedDomains,
       error
@@ -210,13 +151,14 @@ export default class DomainSearch extends Component {
 
     const domainCount = selectedDomains.length;
     const hasExactMatch = results && results.exactMatchDomain && results.exactMatchDomain.available;
+    const cartUrl = `https://www.${baseUrl}/api/v1/cart/${plid}/?redirect=true`;
     const items = this.generateCartItems();
 
     // Prevent navigation when domains are selected and user attempts to navigate
     // outside of the domain purchase path
     window.onbeforeunload = () => {
       // Most browsers control the return message to the user, we can safely return an empty string here.
-      return !addingToCart && (hasExactMatch || domainCount > 0) ? '' : undefined;
+      return !submitting && (hasExactMatch || domainCount > 0) ? '' : undefined;
     };
 
     return (
@@ -225,25 +167,27 @@ export default class DomainSearch extends Component {
           <div className="input-group">
             <div className="input-group2">
               <label>
-                <input type="search" value={ this.state.domain } onChange={ this.handleChange } className="search-field" placeholder={ this.props.text.placeholder } />
+                <input type="search" value={ this.state.domain } onChange={ this.handleChange } className="search-field" placeholder={ text.placeholder }/>
               </label>
-              <input type="submit" className="rstore-domain-search-button search-submit btn btn-primary" disabled={ searching } value={ this.props.text.search }/>
+              <input type="submit" className="rstore-domain-search-button search-submit btn btn-primary" disabled={ searching || submitting } value={ text.search }/>
             </div>
           </div>
             { error && <div className="rstore-error">Error: { error }</div> }
-            { (addingToCart || searching) && <div className="rstore-loading"></div> }
-            { results && <SearchResults results={ results } cartClick={ domain => this.handleSelectClick(domain) } text={ this.props.text }/> }
+            { searching && <div className="rstore-loading"></div> }
+            { results && <SearchResults results={ results } cartClick={ domain => this.handleSelectClick(domain) } text={ text }/> }
         </form>
 
         { results &&
-          <form className="input-continue-btn" method="POST">
+          <form className="input-continue-btn" method="POST" action= { cartUrl }>
             <input type="hidden" name="items" value={ items } />
-            <button type="button" className="rstore-domain-continue-button btn btn-secondary"
+            <button
+              type="submit"
+              className="rstore-domain-continue-button btn btn-secondary"
               onClick={ this.handleContinueClick }
               disabled={ domainCount === 0 && !hasExactMatch }
             >
-              { this.props.text.cart }
-              { (domainCount > 0) && `(${domainCount} ${this.props.text.selected})` }
+              { text.cart }
+              { (domainCount > 0) && `(${domainCount} ${text.selected})` }
             </button>
           </form>
         }

--- a/src/DomainSearch.js
+++ b/src/DomainSearch.js
@@ -163,34 +163,44 @@ export default class DomainSearch extends Component {
 
     return (
       <div>
-        <form className="search-form" onSubmit={ this.handleDomainSearch }>
-          <div className="input-group">
-            <div className="input-group2">
-              <label>
-                <input type="search" value={ this.state.domain } onChange={ this.handleChange } className="search-field" placeholder={ text.placeholder }/>
-              </label>
-              <input type="submit" className="rstore-domain-search-button search-submit btn btn-primary" disabled={ searching || submitting } value={ text.search }/>
+        <div className="form-container">
+          <form className="search-form" onSubmit={ this.handleDomainSearch }>
+            <div className="input-group">
+              <input
+                type="search"
+                value={ this.state.domain }
+                onChange={ this.handleChange }
+                className="search-field"
+                placeholder={ text.placeholder }
+              />
+              <input
+                type="submit"
+                className="rstore-domain-search-button search-submit btn btn-primary"
+                disabled={ searching || submitting }
+                value={ text.search }
+              />
             </div>
-          </div>
-            { error && <div className="rstore-error">Error: { error }</div> }
-            { searching && <div className="rstore-loading"></div> }
-            { results && <SearchResults results={ results } cartClick={ domain => this.handleSelectClick(domain) } text={ text }/> }
-        </form>
-
-        { results &&
-          <form className="input-continue-btn" method="POST" action= { cartUrl }>
-            <input type="hidden" name="items" value={ items } />
-            <button
-              type="submit"
-              className="rstore-domain-continue-button btn btn-secondary"
-              onClick={ this.handleContinueClick }
-              disabled={ domainCount === 0 && !hasExactMatch }
-            >
-              { text.cart }
-              { (domainCount > 0) && `(${domainCount} ${text.selected})` }
-            </button>
           </form>
-        }
+
+          { results &&
+            <form className="continue-form" method="POST" action= { cartUrl }>
+              <input type="hidden" name="items" value={ items } />
+              <button
+                type="submit"
+                className="rstore-domain-continue-button btn btn-secondary"
+                onClick={ this.handleContinueClick }
+                disabled={ domainCount === 0 && !hasExactMatch }
+              >
+                { text.cart }
+                { (domainCount > 0) && `(${domainCount} ${text.selected})` }
+              </button>
+            </form>
+          }
+        </div>
+
+        { error && <div className="rstore-error">Error: { error }</div> }
+        { (searching || submitting) && <div className="rstore-loading"></div> }
+        { results && <SearchResults results={ results } cartClick={ domain => this.handleSelectClick(domain) } text={ text }/> }
       </div>
     );
   }

--- a/src/DomainSearch.js
+++ b/src/DomainSearch.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import SearchResults from './SearchResults';
 
@@ -111,9 +111,6 @@ export default class DomainSearch extends Component {
     const items = [];
 
     if (results) {
-      const domainCount = selectedDomains.length;
-      const hasExactMatch = results && results.exactMatchDomain && results.exactMatchDomain.available;
-
       let domains;
 
       if (selectedDomains.length === 0 && results.exactMatchDomain.available) {
@@ -162,46 +159,44 @@ export default class DomainSearch extends Component {
     };
 
     return (
-      <div>
+      <Fragment>
         <div className="form-container">
           <form className="search-form" onSubmit={ this.handleDomainSearch }>
-            <div className="input-group">
-              <input
-                type="search"
-                value={ this.state.domain }
-                onChange={ this.handleChange }
-                className="search-field"
-                placeholder={ text.placeholder }
-              />
-              <input
-                type="submit"
-                className="rstore-domain-search-button search-submit btn btn-primary"
-                disabled={ searching || submitting }
-                value={ text.search }
-              />
-            </div>
+            <input
+              type="search"
+              value={ this.state.domain }
+              onChange={ this.handleChange }
+              className="search-field"
+              placeholder={ text.placeholder }
+            />
+            <input
+              type="submit"
+              className="rstore-domain-search-button search-submit btn btn-primary"
+              disabled={ searching || submitting }
+              value={ text.search }
+            />
           </form>
-
-          { results &&
-            <form className="continue-form" method="POST" action= { cartUrl }>
-              <input type="hidden" name="items" value={ items } />
-              <button
-                type="submit"
-                className="rstore-domain-continue-button btn btn-secondary"
-                onClick={ this.handleContinueClick }
-                disabled={ domainCount === 0 && !hasExactMatch }
-              >
-                { text.cart }
-                { (domainCount > 0) && `(${domainCount} ${text.selected})` }
-              </button>
-            </form>
-          }
         </div>
+
+        { results &&
+          <form className="continue-form" method="POST" action= { cartUrl }>
+            <input type="hidden" name="items" value={ items } />
+            <button
+              type="submit"
+              className="rstore-domain-continue-button btn btn-secondary"
+              onClick={ this.handleContinueClick }
+              disabled={ domainCount === 0 && !hasExactMatch }
+            >
+              { text.cart }
+              { (domainCount > 0) && `(${domainCount} ${text.selected})` }
+            </button>
+          </form>
+        }
 
         { error && <div className="rstore-error">Error: { error }</div> }
         { (searching || submitting) && <div className="rstore-loading"></div> }
         { results && <SearchResults results={ results } cartClick={ domain => this.handleSelectClick(domain) } text={ text }/> }
-      </div>
+      </Fragment>
     );
   }
 }

--- a/src/tests/Domain.test.js
+++ b/src/tests/Domain.test.js
@@ -38,7 +38,7 @@ describe('Domain', () => {
   it('should successfully add when domain is selected', () => {
     const wrapper = mount(<Domain {...props} />);
 
-    wrapper.find('a').simulate('click');
+    wrapper.find('button').simulate('click');
 
     setTimeout(() => {
       expect(wrapper.state('listPrice')).toHaveLength(1);
@@ -49,7 +49,7 @@ describe('Domain', () => {
     const wrapper = shallow(<Domain {...props} />);
 
     wrapper.setState({ selected: true });
-    wrapper.find('a').simulate('click');
+    wrapper.find('button').simulate('click');
 
     expect(wrapper.find('.rstore-success')).toHaveLength(1);
   });


### PR DESCRIPTION
This addresses an issue where certain Safari users visiting reseller sites with custom domains for the first time were not able to add products to the cart due to the browser's third-party cookie policy. By default, Safari will block third party cookies. By changing the "Continue to Cart" button to a form `POST`, we are making it an explicit navigation to secureserver.net which allows the required cookies to be written. 

This change also relates to https://github.com/godaddy/wp-reseller-store/pull/81