### PR TITLE
Fix broken open in new tab release

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,3 @@
 *
 */
-!dist/index.js
+!dist/build/static/js/bundle.min.js

--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ This app is open source! That means we want your contributions!
 3. Create pull-requests and help us make it better!
 
 ## Changelog
+  - v4.1.0
+    - Add open in new tab option
+
   - v3.1.0
     - Prevent page navigation when domains are selected
 

--- a/README.md
+++ b/README.md
@@ -25,18 +25,21 @@ You can view a demo of the domain search component at https://godaddy.github.io/
   - Please visit [https://www.secureserver.net/api/explore/](https://www.secureserver.net/api/explore/) for the official Storefront API documentation.
 
 ## Usage
+
 - Add the following HTML to the page that you want the domain search component to appear on. The compiled JS is located in `dist/index.js`.
 
 ```html
-<div class="rstore-domain-search" data-plid='1592'>Domain Search</div>
+<div class="rstore-domain-search" data-plid="1592">Domain Search</div>
 ```
 
 Optional parameter to change number of results returned in the search
+
 ```
 data-page_size="5"
 ```
 
 The domain search component is internationalizable. To change any of the strings, provide the following data attributes in the `div`
+
 ```
 data-text_placeholder="Find your perfect domain name"
 data-text_search="Search"
@@ -51,17 +54,22 @@ data-new_tab=true
 `data-text_available` and `data-text_not_available` fields support text substitution, {domain_name} in the provided text will be replaced by the actual domain name searched.
 
 Example Usage
+
 ```html
-<div class="rstore-domain-search" data-plid='1592'
-    data-text_placeholder="Find your perfect domain name"
-    data-text_search="Search"
-    data-text_available="Congrats, {domain_name} is available!"
-    data-text_not_available="Sorry, {domain_name} is taken."
-    data-text_cart="Continue to Cart"
-    data-text_select="Select"
-    data-text_selected="Selected"
-    data-new_tab=true
->Domain Search</div>
+<div
+  class="rstore-domain-search"
+  data-plid="1592"
+  data-text_placeholder="Find your perfect domain name"
+  data-text_search="Search"
+  data-text_available="Congrats, {domain_name} is available!"
+  data-text_not_available="Sorry, {domain_name} is taken."
+  data-text_cart="Continue to Cart"
+  data-text_select="Select"
+  data-text_selected="Selected"
+  data-new_tab="true"
+>
+  Domain Search
+</div>
 ```
 
 ## Browser Requirements
@@ -114,33 +122,41 @@ This app is open source! That means we want your contributions!
 3. Create pull-requests and help us make it better!
 
 ## Changelog
-  - v4.1.0
-    - Add open in new tab option
 
-  - v3.1.0
-    - Prevent page navigation when domains are selected
+- v4.1.0
 
-  - v3.0.0
-    - Update dependencies
-    - Update api calls
-    - Update CSS for responsive layout
-    - Add domain disclaimers
+  - Add open in new tab option
 
-  - v2.1.6
-    - Update api endpoint
+- v3.1.0
 
-  - v2.1.4
-    - Add continue to cart button
-    - Update UX 
+  - Prevent page navigation when domains are selected
 
-  - v2.1.3
-    - Include full domain on taken search results
-  
-  - v2.1.0
-    - Upgrade to React 16
-  
-  - v2.0.0 
-    - Initial Release
+- v3.0.0
+
+  - Update dependencies
+  - Update api calls
+  - Update CSS for responsive layout
+  - Add domain disclaimers
+
+- v2.1.6
+
+  - Update api endpoint
+
+- v2.1.4
+
+  - Add continue to cart button
+  - Update UX
+
+- v2.1.3
+
+  - Include full domain on taken search results
+
+- v2.1.0
+
+  - Upgrade to React 16
+
+- v2.0.0
+  - Initial Release
 
 ## Contributors
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "domain-search",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3260,7 +3260,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -3281,12 +3282,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -3301,17 +3304,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -3428,7 +3434,8 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -3440,6 +3447,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -3454,6 +3462,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -3461,12 +3470,14 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -3485,6 +3496,7 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -3565,7 +3577,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -3577,6 +3590,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -3662,7 +3676,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -3698,6 +3713,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -3717,6 +3733,7 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -3760,12 +3777,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -7492,7 +7511,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7513,12 +7533,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7533,17 +7555,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7660,7 +7685,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7672,6 +7698,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7686,6 +7713,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7693,12 +7721,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -7717,6 +7747,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7797,7 +7828,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7809,6 +7841,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7894,7 +7927,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7930,6 +7964,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7949,6 +7984,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7992,12 +8028,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "domain-search",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "description": "React-based domain search widget used for designing and building custom GoDaddy reseller storefronts",
   "main": "dist/build/static/js/bundle.min.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "domain-search",
   "version": "4.0.2",
   "description": "React-based domain search widget used for designing and building custom GoDaddy reseller storefronts",
-  "main": "dist/index.js",
+  "main": "dist/build/static/js/bundle.min.js",
   "scripts": {
     "start": "react-scripts start",
     "build": "npm run build:react && npm run build:bundle",


### PR DESCRIPTION
The latest release has an empty `dist` due to an un-released change from years ago that changed the `dist/index.js` path

This change:

- Points the `main` script to the correct location
- Updates the version to `4.1.0` as open in new tab is a backwards compatible feature
- Updates the change log